### PR TITLE
[TASK] Add 11.5 branch and restore core main (v12) support

### DIFF
--- a/src/Info/CoreInformation.php
+++ b/src/Info/CoreInformation.php
@@ -19,12 +19,13 @@ class CoreInformation
     /**
      * Important: highest first
      */
-    private const VERSIONS = [11, 10, 9];
+    private const VERSIONS = [12, 11, 10, 9];
 
     /**
      * Important: latest version will map to main automatically
      */
     private const BRANCHMAPPING = [
+        11 => '11.5',
         10 => '10.4',
         9 => '9.5'
     ];


### PR DESCRIPTION
This change adds the branch aliasing for v11 (11 => 11.5)
and additional tells the extractor that we have a "v12"
version, which is picked up for "main" branch. This should
restore the ability to get translation files in current
v12 monorepo instances and make backend language selectable
for users, which is not possible with missing language packs.

Resolves #4
