### PR TITLE
[TASK] Add support for `ext:webhooks`

### DIFF
--- a/src/Info/CoreInformation.php
+++ b/src/Info/CoreInformation.php
@@ -37,7 +37,7 @@ class CoreInformation
         'filemetadata', 'fluid', 'frontend', 'fluid_styled_content', 'form', 'frontend', 'impexp',
         'indexed_search', 'info', 'install', 'linkvalidator', 'lowlevel', 'opendocs', 'reactions',
         'recordlist', 'recycler', 'redirects', 'reports', 'scheduler', 'seo', 'setup', 'sys_note',
-         't3editor', 'tstemplate', 'viewpage', 'workspaces',
+         't3editor', 'tstemplate', 'viewpage', 'webhooks', 'workspaces',
     ];
     private const CORE_EXTENSIONS_9 = [
         'info', 'rsaauth', 'sys_action', 'taskcenter'


### PR DESCRIPTION
TYPO3 v12.3 contains the new system extension `ext:webhooks`.

This changes adds the new system extension to ensure translation
handling is working for it.

See: https://review.typo3.org/c/Packages/TYPO3.CMS/+/77362