### PR TITLE
[TASK] Align for TYPO3 Core Development branching

### DIFF
--- a/src/Info/CoreInformation.php
+++ b/src/Info/CoreInformation.php
@@ -18,13 +18,18 @@ class CoreInformation
 
     /**
      * Important: highest first
+     *
+     * First version in array defines the version for monorepo `main` branch. {@see self::getLatestVersion()}
      */
-    private const VERSIONS = [13, 12, 11, 10, 9];
+    private const VERSIONS = [14, 13, 12, 11, 10, 9];
 
     /**
      * Important: latest version will map to main automatically
+     *
+     * Major version to main development branch mapping.
      */
     private const BRANCHMAPPING = [
+        13 => '13.4',
         12 => '12.4',
         11 => '11.5',
         10 => '10.4',


### PR DESCRIPTION
TYPO3 Core Development branched out `13.4` to
start with 14.x development on the main branch.

This change takes care to regonize the new branch,
and match use branch `main` for TYPO3 v14 now.

-------------------------------------------------------------

Note: I guess that branch 13.4 must be added in the
TYPO3 project to be listed - and I guess inital filled
with current main keys ? Not sure about that process
