### PR TITLE
chore(composer): remove config.allow-plugins.php-http/discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
 			"php": "8.3"
 		},
 		"allow-plugins": {
-			"php-http/discovery": true,
 			"symfony/flex": true,
 			"symfony/runtime": true
 		},


### PR DESCRIPTION
The "php-http/discovery" package is not installed, so the configuration option can safely be removed.