### PR TITLE
Clean up TranslationApi class

### DIFF
--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -1,18 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method App\\Api\\Wrapper\\TranslationApi\:\:getBuilds\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: src/Api/Wrapper/TranslationApi.php
-
-		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: src/Api/Wrapper/TranslationApi.php
-
-		-
 			message: '#^Method App\\Command\\Extract\\ExtractExtensionCommand\:\:downloadProject\(\) has parameter \$listOfLanguages with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1

--- a/src/Api/Wrapper/TranslationApi.php
+++ b/src/Api/Wrapper/TranslationApi.php
@@ -27,17 +27,7 @@ class TranslationApi extends Client
         return $this->client->translation->downloadProjectBuild($projectId, $buildId);
     }
 
-    public function getBuilds(int $projectId)
-    {
-        $params = [
-            'limit' => 10,
-        ];
-        return $this->client->translation->getProjectBuilds($projectId, $params);
-    }
-
     /**
-     * @param int $projectId
-     * @return int build id
      * @throws NoFinishedProjectBuildFoundException
      */
     public function getLastFinishedBuildId(int $projectId): int
@@ -46,7 +36,7 @@ class TranslationApi extends Client
             'limit' => 10,
         ];
         $items = $this->client->translation->getProjectBuilds($projectId, $params);
-        if (!$items) {
+        if (count($items) === 0) {
             throw new NoFinishedProjectBuildFoundException(sprintf('No builds found for project "%s"', $projectId));
         }
         foreach ($items as $item) {
@@ -56,7 +46,5 @@ class TranslationApi extends Client
             }
         }
         throw new NoFinishedProjectBuildFoundException(sprintf('No finished build found for project "%s"', $projectId));
-
     }
-
 }


### PR DESCRIPTION
`getProjectBuilds()` called in method `getLastFinishedBuildId()` returns a `ModelCollection` object. Therefore, the check for `!$items` was always false. As `ModelCollection` implements `Countable` we can fix the condition with a `count()` call.

The docblock annotations for `getLastFinishedBuildId()` are redundant and have been removed.

Additionally, the method `getBuilds()` was not used in the project and is dropped.