### PR TITLE
Clean up app:status:overview command

### DIFF
--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -13,30 +13,6 @@ parameters:
 			path: src/Command/Extract/ExtractExtensionCommand.php
 
 		-
-			message: '#^Method App\\Command\\Status\\OverviewStatusCommand\:\:spread\(\) has parameter \$add with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Command/Status/OverviewStatusCommand.php
-
-		-
-			message: '#^Method App\\Command\\Status\\OverviewStatusCommand\:\:spread\(\) has parameter \$existing with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Command/Status/OverviewStatusCommand.php
-
-		-
-			message: '#^Method App\\Command\\Status\\OverviewStatusCommand\:\:spread\(\) is unused\.$#'
-			identifier: method.unused
-			count: 1
-			path: src/Command/Status/OverviewStatusCommand.php
-
-		-
-			message: '#^Method App\\Command\\Status\\OverviewStatusCommand\:\:spread\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Command/Status/OverviewStatusCommand.php
-
-		-
 			message: '#^Method App\\Command\\Status\\ProjectStatusCommand\:\:exportProject\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/src/Command/Status/OverviewStatusCommand.php
+++ b/src/Command/Status/OverviewStatusCommand.php
@@ -16,10 +16,12 @@ use Symfony\Component\Console\Style\SymfonyStyle;
     description: 'Status of all crowdin projects',
     hidden: false
 )]
-class OverviewStatusCommand extends Command
+final class OverviewStatusCommand extends Command
 {
-    public function __construct(protected StatusService $statusService, ?string $name = null)
-    {
+    public function __construct(
+        private StatusService $statusService,
+        ?string $name = null
+    ) {
         parent::__construct($name);
     }
 
@@ -28,18 +30,9 @@ class OverviewStatusCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $io->title('Status of all projects');
 
-        $response = $this->statusService->getStatus(true);
+        $this->statusService->getStatus(true);
 
         $io->info('Status has been exported!');
         return Command::SUCCESS;
     }
-
-    private function spread(array $existing, array $add): array
-    {
-        foreach ($add as $value) {
-            $existing[] = $value;
-        }
-        return $existing;
-    }
-
 }


### PR DESCRIPTION
- The private `spread()` method is not used and therefore removed.
- The `$response` variable is not used and therefore removed.
- Mark the class as final as it should not be extended.