### PR TITLE
Clean up CoreInformation class

### DIFF
--- a/phpstan.baseline.neon
+++ b/phpstan.baseline.neon
@@ -73,42 +73,6 @@ parameters:
 			path: src/Entity/ProjectConfiguration.php
 
 		-
-			message: '#^Method App\\Info\\CoreInformation\:\:getAllCoreBranches\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Info/CoreInformation.php
-
-		-
-			message: '#^Method App\\Info\\CoreInformation\:\:getAllCoreExtensionKeys\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Info/CoreInformation.php
-
-		-
-			message: '#^Method App\\Info\\CoreInformation\:\:getCoreExtensionKeys\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Info/CoreInformation.php
-
-		-
-			message: '#^Method App\\Info\\CoreInformation\:\:getVersionForBranchName\(\) should return int but returns int\|false\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Info/CoreInformation.php
-
-		-
-			message: '#^Offset 9\|10\|11\|12\|13\|14 might not exist on array\{13\: ''13\.4'', 12\: ''12\.4'', 11\: ''11\.5'', 10\: ''10\.4'', 9\: ''9\.5''\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 1
-			path: src/Info/CoreInformation.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between 9\|10\|11\|12\|13\|false and null will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: src/Info/CoreInformation.php
-
-		-
 			message: '#^Method App\\Info\\LanguageInformation\:\:getLanguageForCrowdin\(\) should return string but returns int\|string\.$#'
 			identifier: return.type
 			count: 1

--- a/src/Info/CoreInformation.php
+++ b/src/Info/CoreInformation.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Info;
 
-class CoreInformation
+readonly class CoreInformation
 {
     /**
      * Important: highest first
@@ -28,12 +28,43 @@ class CoreInformation
 
     // rte_ckeditor got no translations
     private const array CORE_EXTENSIONS = [
-        'about', 'adminpanel',
-        'backend', 'beuser', 'belog', 'core', 'extbase', 'extensionmanager', 'felogin', 'filelist',
-        'filemetadata', 'fluid', 'frontend', 'fluid_styled_content', 'form', 'frontend', 'impexp',
-        'indexed_search', 'info', 'install', 'linkvalidator', 'lowlevel', 'opendocs', 'reactions',
-        'recordlist', 'recycler', 'redirects', 'reports', 'scheduler', 'seo', 'setup', 'sys_note',
-        't3editor', 'tstemplate', 'viewpage', 'webhooks', 'workspaces',
+        'about',
+        'adminpanel',
+        'backend',
+        'beuser',
+        'belog',
+        'core',
+        'extbase',
+        'extensionmanager',
+        'felogin',
+        'filelist',
+        'filemetadata',
+        'fluid',
+        'frontend',
+        'fluid_styled_content',
+        'form',
+        'frontend',
+        'impexp',
+        'indexed_search',
+        'info',
+        'install',
+        'linkvalidator',
+        'lowlevel',
+        'opendocs',
+        'reactions',
+        'recordlist',
+        'recycler',
+        'redirects',
+        'reports',
+        'scheduler',
+        'seo',
+        'setup',
+        'sys_note',
+        't3editor',
+        'tstemplate',
+        'viewpage',
+        'webhooks',
+        'workspaces',
     ];
     private const array CORE_EXTENSIONS_9 = [
         'info', 'rsaauth', 'sys_action', 'taskcenter',
@@ -42,14 +73,6 @@ class CoreInformation
     private const array CORE_EXTENSIONS_10 = [
         'dashboard',
     ];
-
-    /**
-     * @return int[]
-     */
-    public static function getAllVersions(): array
-    {
-        return self::VERSIONS;
-    }
 
     public static function getLatestVersion(): int
     {
@@ -63,36 +86,23 @@ class CoreInformation
             return self::getLatestVersion();
         }
         $version = array_search($branch, self::BRANCH_MAPPING, true);
-        if ($version === null) {
+        if ($version === false) {
             throw new \UnexpectedValueException(sprintf('Branch "%s" not found', $branch), 1567647855);
         }
         return $version;
     }
 
-    public static function getBranchNameForVersion(int $version): string
-    {
-        if (!in_array($version, self::VERSIONS, true)) {
-            throw new \UnexpectedValueException(sprintf('Version "%s" is not supported', $version), 1567647856);
-        }
-        if ($version === self::getLatestVersion()) {
-            return 'main';
-        }
-        return self::BRANCH_MAPPING[$version];
-    }
-
-    public static function getCoreExtensionKeys(int $version): array
-    {
-        if ($version >= 10) {
-            return array_merge(self::CORE_EXTENSIONS, self::CORE_EXTENSIONS_10);
-        }
-        return array_merge(self::CORE_EXTENSIONS, self::CORE_EXTENSIONS_9);
-    }
-
+    /**
+     * @return list<string> List of Core extension keys
+     */
     public static function getAllCoreExtensionKeys(): array
     {
         return array_merge(self::CORE_EXTENSIONS, self::CORE_EXTENSIONS_9, self::CORE_EXTENSIONS_10);
     }
 
+    /**
+     * @return list<string> List of version numbers like "13.4", "12.4" and "main"
+     */
     public static function getAllCoreBranches(): array
     {
         $branches = array_values(self::BRANCH_MAPPING);


### PR DESCRIPTION
This class is used by the extract core command.

Some methods are not in use anymore and has been dropped:
- `getAllVersions()`
- `getBranchNameForVersion()`
- `getCoreExtensionKeys()`

The iterable return types have been added, where appropriate.

The `array_search()` function returns `false` on error, not `null`. This has been corrected in the `getVersionForBranchName()`.

For better readability each extension key in the `CORE_EXTENSIONS` constant is now in a separate line.

As the class holds no state it is marked as readonly.