### PR TITLE
Deactivate build/extract workflow on push

### DIFF
--- a/.github/workflows/crowdin-build.yml
+++ b/.github/workflows/crowdin-build.yml
@@ -2,9 +2,6 @@ name: Crowdin Build
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - v3
   schedule:
     - cron:  '0 */2 * * *'
 jobs:

--- a/.github/workflows/crowdin-extract.yml
+++ b/.github/workflows/crowdin-extract.yml
@@ -2,9 +2,6 @@ name: Crowdin Extract
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - v3
   schedule:
     - cron:  '30 */2 * * *'
 jobs:


### PR DESCRIPTION
Currently, the build and extract workflows run on every push (and thankfully fail because of missing Crowdin access key). Then the commit is marked as failed. These workflows should not run on push, only on schedule or manually triggered.